### PR TITLE
Remove uppercase alphabets

### DIFF
--- a/lib/nameGenerator.js
+++ b/lib/nameGenerator.js
@@ -4,7 +4,7 @@ class NameGenerator {
   constructor() {
     this.nameCounter = 1;
     this.decToAnyOptions = {
-      alphabet: 'etnrisouaflchpdvmgybwESxTNCkLAOM_DPHBjFIqRUzWXVJKQGYZ',
+      alphabet: 'etnrisouaflchpdvmgybwxk_jqz',
     };
   }
 


### PR DESCRIPTION
- Remove uppercase alphabets from name generator file.
- Browsers are converting selectors to lowercase and applying their style to elements. Chrome and Firefox browsers are applying styles of classes 't' and 'T' to element div having class 't'.