### PR TITLE
Chore: change Node testing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 sudo: true
 dist: trusty
 node_js:
-  - 4
-  - 5
   - 6
+  - 8
+  - 10
 install:
   - yarn
 script: npm run test


### PR DESCRIPTION
This is not a drop of Node v4, as this project is using babel. Node v4/5 is just dropped, as other dependencies requires at least Node v6 in #52.