### PR TITLE
Chore: update parse5-traverse (closes #58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "object.entries": "^1.0.4",
     "object.values": "^1.0.4",
     "parse5": "^5.0.0",
-    "parse5-traverse": "^1.0.2",
+    "parse5-traverse": "^1.0.3",
     "postcss": "^6.0.17",
     "recast": "^0.15.0"
   },

--- a/test/replace.html.js
+++ b/test/replace.html.js
@@ -138,3 +138,10 @@ test('should replace shouldTriggerIdAttribute glob an normal mixed',
   '<table anything="test a" another="a" data-one="b" data-two="b" id="id"></table>',
   { triggerIdAttributes: ['anything', 'another', /data-*/] },
 );
+
+test('should replace inside template | issue #58',
+  replaceHtmlMacro,
+  ['.selector', '.another-selector'],
+  '<div class="selector"><template type="selector"><div class="another-selector"></div></template></div>',
+  '<div class="a"><template type="selector"><div class="b"></div></template></div>',
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,9 +3251,9 @@ parse-ms@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
 
-parse5-traverse@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/parse5-traverse/-/parse5-traverse-1.0.2.tgz#2e8215e1141c02b887d969fb6b8a34322316c68f"
+parse5-traverse@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/parse5-traverse/-/parse5-traverse-1.0.3.tgz#e912762a1f8879f35107bd6e437e71a97ec938c7"
 
 parse5@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Just updated fixed lib: `parse5-traverse`