### PR TITLE
Fix #84 and #83

### DIFF
--- a/lib/replace/js.js
+++ b/lib/replace/js.js
@@ -41,7 +41,24 @@ const replaceJs = (code, espreeOptions) => {
 
   traverse(ast, {
     pre: (node) => {
-      if (node.type === 'Literal' && typeof node.value === 'string') {
+      // Avoid recursing into a "in" node since it can't be a CSS class or variable.
+      if (node.type === 'BinaryExpression' && node.operator === 'in') {
+        return false;
+      }
+
+      if (node.type === 'TemplateElement' && 'raw' in node.value) {
+        // eslint-disable-next-line
+        const raw = node.value.raw.replace(allRegex.templateSelectors, function (txt, p1, p2, p3) {
+          // p3 contains the content of the class=' or id=", so let's replace them
+          const newValue = ` ${p3} `;
+          const replacedAttr = newValue.replace(newValue, match => replaceString(match, regex, ' ', { countStats: false }));
+          // eslint-disable-next-line
+          return p1 + '=' + p2 + replacedAttr.slice(1, replacedAttr.length - 1) + p2;
+        });
+
+        // eslint-disable-next-line no-param-reassign
+        node.value.raw = raw;
+      } else if (node.type === 'Literal' && typeof node.value === 'string') {
         // eslint-disable-next-line no-param-reassign
         node.raw = node.raw.replace(node.raw, match => replaceString(match, regex));
 
@@ -58,6 +75,8 @@ const replaceJs = (code, espreeOptions) => {
         // eslint-disable-next-line no-param-reassign
         node.value = replacedCssVariables.slice(1, replacedCssVariables.length - 1);
       }
+
+      return true;
     },
   });
 

--- a/lib/replace/regex.js
+++ b/lib/replace/regex.js
@@ -4,4 +4,5 @@ export default {
   attributeSelectors: /\[\s*(class|id)\s*([*^$|~]?)=\s*("[^\]]*?"|'[^\]]*?'|[^\]]*)[^\]]*?\]/g, // matches attribute selectors of html just with class or id in it with `$=`, `^=` or `*=`, e.g.: [class*="selector"]. 3 group matches, first `class` or `id`, second regex operator, third the string
   keyframes: /@(-[a-z]*-)*keyframes\s+([a-zA-Z0-9_-]+)/g, // matches keyframes and just the first group the first matched non-whitespace characters - e.g. matches: `@keyframes    my-KeyFra_me`
   cssVariables: /var\(([\s\S]*?)\)/g, // matches everything inside `var(match)` - e.g. var(my-variable)
+  templateSelectors: /(class|id)+\s*=\s*(['"])((?:.(?!\2))*.?)\2/g, // matches class="xyz" and id='xyz' in template node, first is "class" or "id", second is the quote type and last is the class names or id
 };

--- a/test/replace.js.js
+++ b/test/replace.js.js
@@ -97,6 +97,24 @@ test('check optional try catch | issue #73',
   '.jp-block{}.jp-block-two{}',
 );
 
+test('check "key" in object non replacement | issue #83',
+  replaceJsMacro,
+  `
+    const key = "jp-block" in obj;
+  `,
+  `
+    const key = "jp-block" in obj;
+  `,
+  '.jp-block{}',
+);
+
+test('replace in template | issue #84',
+  replaceJsMacro,
+  'const templ = `<div class="jp-block" id="someid">`;',
+  'const templ = `<div class="a" id="b">`;',
+  '.jp-block{}#someid{}',
+);
+
 test('replace css variables | issue rename-css-selectors#38',
   replaceJsMacro,
   `


### PR DESCRIPTION
This fixes both #84 and #83 (this one is trivial, I have no time to split it in a different PR).

Finally, the `Template` code was much harder than I initially thought since we have to modify the `TemplateElement` node and not the one of the `Template` node.
The most difficult part was to figure out what to change in the templated string and what not. I've build a RegEx for this (and stored in regex.js like all others) using reversed look ahead (so it accepts both quote type and stops on the same quote type as found initially).

There is still a bug in recast if your template's literal ends in `_` before a `${xyz}` part (like in `<div id="iter_${i}">`, this get replaced to `<div id="iter_ ${i}">` (with extra space breaking the code). I've reported to them, but this is not `rcs-core` business. 

I've added tests for all these cases.   