### PR TITLE
Prevent mini size

### DIFF
--- a/lib/baseLibrary.js
+++ b/lib/baseLibrary.js
@@ -8,6 +8,7 @@ export class BaseLibrary {
   constructor() {
     this.values = {};
     this.compressedValues = {};
+    this.reserved = [];
     this.excludes = [];
     this.excludesRegex = [];
     this.prefix = '';
@@ -18,6 +19,7 @@ export class BaseLibrary {
   reset() {
     this.values = {};
     this.compressedValues = {};
+    this.reserved = [];
     this.excludes = [];
     this.excludesRegex = [];
     this.prefix = '';
@@ -30,6 +32,17 @@ export class BaseLibrary {
   fillLibrary() {
   } // /fillLibrary
 
+  static hasReservedValue(value) {
+    // eslint-disable-next-line no-console
+    console.warn(`WARNING: '${value}' does not exist beforehand in the rename table,` +
+                 ' but appears in the compressed map. Either:');
+    // eslint-disable-next-line no-console
+    console.warn(`- Create a CSS rule with '${value}' and re-run the process, or`);
+    // eslint-disable-next-line no-console
+    console.warn('- Add the value to the reserved selectors table so it\'s not used for renaming');
+    return `${value}_conflict`;
+  } // /hasReservedValue
+
   get(value, opts = {}) {
     const optionsDefault = {
       isOriginalValue: true,
@@ -38,9 +51,13 @@ export class BaseLibrary {
 
     const options = merge({}, optionsDefault, opts);
 
+    if (!this.values[value] && options.isOriginalValue && this.compressedValues[value]) {
+      return BaseLibrary.hasReservedValue(value);
+    }
+
     let result = this.values[value] || value;
 
-    // fail on setted exludes
+    // fail on setted excludes
     if (this.isExcluded(value)) {
       return value;
     }
@@ -140,6 +157,21 @@ export class BaseLibrary {
       (this.excludes).push(toExclude);
     }
   } // /setExclude
+
+  setReserved(toReserve) {
+    if (!toReserve) return;
+
+    this.reserved = [];
+    if (!Array.isArray(toReserve)) {
+      this.reserved.push(toReserve);
+    } else {
+      this.reserved = [...new Set(toReserve)];
+    }
+  } // /setReserved
+
+  isReserved(string) {
+    return includes(this.reserved, string);
+  }
 
   isExcluded(string) {
     if (includes(this.excludes, string)) {

--- a/lib/selectorLibrary.js
+++ b/lib/selectorLibrary.js
@@ -97,6 +97,9 @@ class SelectorLibrary extends BaseLibrary {
     }
 
     if (!result) {
+      if (this.compressedSelectors[matchedSelector]) {
+        return BaseLibrary.hasReservedValue(selector);
+      }
       return selector;
     }
 

--- a/test/baseLibrary.js
+++ b/test/baseLibrary.js
@@ -30,6 +30,34 @@ test('exclude | should exclude nothing', (t) => {
   t.is(rcs.baseLibrary.excludes.length, 0);
 });
 
+/* ******** *
+ * RESERVED *
+ * ******** */
+test('reserved | should reserve variables', (t) => {
+  rcs.baseLibrary.setReserved(['a', 'b']);
+
+  t.is(rcs.baseLibrary.reserved.length, 2);
+});
+
+test('reserved | should just reserve once', (t) => {
+  rcs.baseLibrary.setReserved(['a', 'a']);
+
+  t.is(rcs.baseLibrary.reserved.length, 1);
+  t.is(rcs.baseLibrary.reserved[0], 'a');
+});
+
+test('reserved | should support resetting', (t) => {
+  rcs.baseLibrary.setReserved();
+
+  t.is(rcs.baseLibrary.reserved.length, 0);
+});
+
+test('reserved | is queriable', (t) => {
+  rcs.baseLibrary.setReserved('a');
+
+  t.true(rcs.baseLibrary.isReserved('a'));
+  t.falsy(rcs.baseLibrary.isReserved('c'));
+});
 
 /* *********** *
  * SETMULTIPLE *
@@ -328,4 +356,19 @@ test('get | should not get excluded values but already set ones', (t) => {
   t.is(rcs.baseLibrary.get('move'), 'move');
   t.is(rcs.baseLibrary.get('animate'), 'b');
   t.is(rcs.baseLibrary.get('more'), 'c');
+});
+
+test('get | should warn if using renamed selector', (t) => {
+  rcs.baseLibrary.values = {
+    move: 'a',
+  };
+  rcs.baseLibrary.compressedValues = {
+    a: 'move',
+  };
+
+  const moveSelector = rcs.baseLibrary.get('move');
+  const aSelector = rcs.baseLibrary.get('a');
+
+  t.is(moveSelector, 'a');
+  t.not(aSelector, 'a');
 });

--- a/test/selectorLibrary.js
+++ b/test/selectorLibrary.js
@@ -84,6 +84,16 @@ test('get | extend true', (t) => {
   t.is(dotTestSelector.selector, '.test');
 });
 
+test('get | insure no mix if using existing selector', (t) => {
+  t.context.setSelectors();
+
+  const testSelector = rcs.selectorLibrary.get('test');
+  const aSelector = rcs.selectorLibrary.get('a');
+
+  t.is(testSelector, 'a');
+  t.not(aSelector, 'a');
+});
+
 
 /* ****** *
  * GETALL *


### PR DESCRIPTION
This should fix #88.

The idea here is to emit a warning whenever a selector is found in the compressed/renamed map and not in the uncompressed map (something is really broken if it's the case). It also prevent silent error by returning the selector appended with `_conflict` to avoid selecting the bad elements.
