### PR TITLE
Fix label for attribute

### DIFF
--- a/lib/replace/html.js
+++ b/lib/replace/html.js
@@ -80,6 +80,11 @@ const replaceHtml = (code, opts = {}) => {
             selectorType = '#';
           }
 
+          if (node.tagName === 'label' && attr.name === 'for') {
+            selectorType = '#';
+          }
+
+
           // following will replace each whitespace
           // seperated value with its renamed one
           // eslint-disable-next-line no-param-reassign

--- a/lib/replace/regex.js
+++ b/lib/replace/regex.js
@@ -1,8 +1,8 @@
 export default {
   selectors: /(#|\.)[^\s.{)[>+,]+/g, // matches all selectors beginning with . or # - e.g. .matching#alsomatch .matchmetoo
   strings: /"\s*[\S\s]*?\s*"|'\s*[\S\s]*?\s*'/g, // matches strings such as: 'hello' or "hello"
-  attributeSelectors: /\[\s*(class|id)\s*([*^$|~]?)=\s*("[^\]]*?"|'[^\]]*?'|[^\]]*)[^\]]*?\]/g, // matches attribute selectors of html just with class or id in it with `$=`, `^=` or `*=`, e.g.: [class*="selector"]. 3 group matches, first `class` or `id`, second regex operator, third the string
+  attributeSelectors: /\[\s*(class|id|for)\s*([*^$|~]?)=\s*("[^\]]*?"|'[^\]]*?'|[^\]]*)[^\]]*?\]/g, // matches attribute selectors of html just with class, for or id in it with `$=`, `^=` or `*=`, e.g.: [class*="selector"]. 3 group matches, first `class`, `for` or `id`, second regex operator, third the string
   keyframes: /@(-[a-z]*-)*keyframes\s+([a-zA-Z0-9_-]+)/g, // matches keyframes and just the first group the first matched non-whitespace characters - e.g. matches: `@keyframes    my-KeyFra_me`
   cssVariables: /var\(\s*(--[^,\s]+?)(?:\s*,\s*(.+))?\s*\)/g, // matches everything inside `var(match)` - e.g. var(my-variable)
-  templateSelectors: /(class|id)+\s*=\s*(['"])((?:.(?!\2))*.?)\2/g, // matches class="xyz" and id='xyz' in template node, first is "class" or "id", second is the quote type and last is the class names or id
+  templateSelectors: /(class|for|id)+\s*=\s*(['"])((?:.(?!\2))*.?)\2/g, // matches class="xyz", for="xyz" and id='xyz' in template node, first is "class" or "for" or "id", second is the quote type and last is the class names or id
 };

--- a/test/replace.html.js
+++ b/test/replace.html.js
@@ -50,6 +50,13 @@ test('should replace class selectors based on issue #50',
   '<p class="a">text with \'single quote</p><p class="a">another s\'ingle quote</p>',
 );
 
+test('should replace for attribute too based on issue #87',
+  replaceHtmlMacro,
+  '#id1 {}',
+  '<input id="id1"><label for="id1">some label</label>',
+  '<input id="a"><label for="a">some label</label>',
+);
+
 test('should replace class selectors in a normal html file',
   replaceHtmlMacro,
   '.jp-block {} .jp-block__element {}',


### PR DESCRIPTION
Fix #87.
This fixes the missing renaming for `label for` attribute since this also expect an id (usually from an `input`)

