### PR TITLE
Independant name generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ yarn add rcs-core
 - [rcs.selectorsLibrary](docs/api/selectorslibrary.md)
 - [rcs.keyframesLibrary](docs/api/keyframeslibrary.md)
 - [rcs.cssVariablesLibrary](docs/api/cssvariableslibrary.md)
+- [rcs.useCustomGenerator](docs/api/usecustomgenerator.md)
 
 ## Plugins
 - Gulp Plugin: [gulp-rcs](https://www.npmjs.com/package/gulp-rcs)

--- a/lib/attributeLibrary.js
+++ b/lib/attributeLibrary.js
@@ -10,8 +10,8 @@ import { BaseLibrary } from './baseLibrary';
 // It has to be specialized for each type (likely class or id), and thus
 // any logic of selection (like . or #) is defined in the child class, not this one.
 export class AttributeLibrary extends BaseLibrary {
-  constructor() {
-    super();
+  constructor(name) {
+    super(name);
     this.attributeSelectors = {};
   }
 
@@ -267,7 +267,7 @@ export class AttributeLibrary extends BaseLibrary {
       type: exec[1],
       originalString: attributeSelector,
       regexType: attributeSelectorType,
-      nameGeneratorCounter: new NameGenerator(),
+      nameGeneratorCounter: new NameGenerator('attribute'),
     };
   } // /setAttributeSelector
 
@@ -291,7 +291,7 @@ export class AttributeLibrary extends BaseLibrary {
 
         if (match) {
           match = match[0].replace(/-$/, '');
-          result = `${match}-${value.nameGeneratorCounter.generate()}`;
+          result = `${match}-${value.nameGeneratorCounter.generate(slicedSelector)}`;
         }
       }
 
@@ -308,9 +308,9 @@ export class AttributeLibrary extends BaseLibrary {
           const match = slicedSelector.match(attributeString);
 
           if (match) {
-            result = value.nameGeneratorCounter.generate() +
+            result = value.nameGeneratorCounter.generate(slicedSelector) +
                      match[0] +
-                     value.nameGeneratorCounter.generate();
+                     value.nameGeneratorCounter.generate(slicedSelector);
           }
           break;
         }
@@ -318,7 +318,7 @@ export class AttributeLibrary extends BaseLibrary {
           const match = slicedSelector.match(`^${attributeString}`);
 
           if (match) {
-            result = match[0] + value.nameGeneratorCounter.generate();
+            result = match[0] + value.nameGeneratorCounter.generate(slicedSelector);
           }
           break;
         }
@@ -326,7 +326,7 @@ export class AttributeLibrary extends BaseLibrary {
           const match = slicedSelector.match(`${attributeString}$`);
 
           if (match) {
-            result = value.nameGeneratorCounter.generate() + match[0];
+            result = value.nameGeneratorCounter.generate(slicedSelector) + match[0];
           }
           break;
         }

--- a/lib/baseLibrary.js
+++ b/lib/baseLibrary.js
@@ -2,18 +2,12 @@ import includes from 'array-includes';
 import entries from 'object.entries';
 import merge from 'lodash.merge';
 
-import nameGenerator from './nameGenerator';
+import { NameGenerator } from './nameGenerator';
 
 export class BaseLibrary {
-  constructor() {
-    this.values = {};
-    this.compressedValues = {};
-    this.reserved = [];
-    this.excludes = [];
-    this.excludesRegex = [];
-    this.prefix = '';
-    this.suffix = '';
-    this.meta = {};
+  constructor(name) {
+    this.nameGenerator = new NameGenerator(name);
+    this.reset();
   }
 
   reset() {
@@ -25,9 +19,16 @@ export class BaseLibrary {
     this.prefix = '';
     this.suffix = '';
     this.meta = {};
+    this.nameGenerator.reset();
   } // /reset
 
   // extend methods
+  // Shortcut method to change the alphabet of our name generator
+  setAlphabet(alphabet) {
+    this.nameGenerator.setAlphabet(alphabet);
+  } // /setAlphabet
+
+
   // eslint-disable-next-line class-methods-use-this
   fillLibrary() {
   } // /fillLibrary
@@ -160,11 +161,11 @@ export class BaseLibrary {
   smartAllocate(value, renamedValue) {
     // Try to allocate a random compressed name, and if not possible swap with an existing
     // name to avoid conflict and keep compressed name shorter than the initial value
-    let randomName = renamedValue || nameGenerator.generate();
+    let randomName = renamedValue || this.nameGenerator.generate(value);
 
     // Avoid using an existing or reserved compressed value
     while (this.compressedValues[randomName] || this.isReserved(randomName)) {
-      randomName = nameGenerator.generate();
+      randomName = this.nameGenerator.generate(value);
     }
 
     this.values[value] = randomName;

--- a/lib/classSelectorLibrary.js
+++ b/lib/classSelectorLibrary.js
@@ -2,6 +2,9 @@ import replace from './replace';
 import { AttributeLibrary } from './attributeLibrary';
 
 class ClassSelectorLibrary extends AttributeLibrary {
+  constructor() {
+    super('class');
+  }
 
   // eslint-disable-next-line class-methods-use-this
   getAttributeSelectorRegex() {

--- a/lib/cssVariablesLibrary.js
+++ b/lib/cssVariablesLibrary.js
@@ -4,6 +4,10 @@ import { BaseLibrary } from './baseLibrary';
 import replaceRegex from './replace/regex';
 
 class CssVariablesLibrary extends BaseLibrary {
+  constructor() {
+    super('variable');
+  }
+
   fillLibrary(data) {
     const code = data.toString();
     const result = parse(code);

--- a/lib/idSelectorLibrary.js
+++ b/lib/idSelectorLibrary.js
@@ -2,6 +2,9 @@ import replace from './replace';
 import { AttributeLibrary } from './attributeLibrary';
 
 class IdSelectorLibrary extends AttributeLibrary {
+  constructor() {
+    super('id');
+  }
 
   // eslint-disable-next-line class-methods-use-this
   getAttributeSelectorRegex() {

--- a/lib/keyframesLibrary.js
+++ b/lib/keyframesLibrary.js
@@ -2,6 +2,10 @@ import { BaseLibrary } from './baseLibrary';
 import replace from './replace';
 
 class KeyframesLibrary extends BaseLibrary {
+  constructor() {
+    super('keyframe');
+  }
+
   // eslint-disable-next-line class-methods-use-this
   fillLibrary(data) {
     const code = data.toString();

--- a/lib/nameGenerator.js
+++ b/lib/nameGenerator.js
@@ -1,7 +1,14 @@
 import decToAny from 'decimal-to-any';
 
+let customGenerator = null;
+
+function defaultGenerator(obj) {
+  return decToAny(obj.nameCounter, obj.alphabet.length, obj);
+}
+
 export class NameGenerator {
-  constructor() {
+  constructor(type) {
+    this.type = type;
     this.nameCounter = 1;
     this.decToAnyOptions = {
       alphabet: 'etnrisouaflchpdvmgybwxk_jqz',
@@ -13,12 +20,14 @@ export class NameGenerator {
     this.decToAnyOptions.alphabet = alphabet;
   }
 
-  generate() {
-    const generatedName = decToAny(
-      this.nameCounter,
-      this.decToAnyOptions.alphabet.length,
-      this.decToAnyOptions,
-    );
+  generate(selector) {
+    const genFunc = typeof customGenerator === 'function' ? customGenerator : defaultGenerator;
+    const generatedName = genFunc({
+      selector,
+      type: this.type,
+      alphabet: this.decToAnyOptions.alphabet,
+      nameCounter: this.nameCounter,
+    });
 
     this.nameCounter += 1;
 
@@ -30,4 +39,6 @@ export class NameGenerator {
   }
 }
 
-export default new NameGenerator();
+export const useCustomGenerator = (generator) => {
+  customGenerator = generator;
+};

--- a/lib/selectorsLibrary.js
+++ b/lib/selectorsLibrary.js
@@ -28,6 +28,10 @@ class SelectorsLibrary {
     return this.callOnBoth('reset');
   }
 
+  setAlphabet(alphabet) {
+    return this.callOnBoth('setAlphabet', alphabet);
+  }
+
   getClassSelector() {
     return this.selectors[1];
   }

--- a/test/baseLibrary.js
+++ b/test/baseLibrary.js
@@ -3,8 +3,7 @@ import test from 'ava';
 import rcs from '../lib';
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.baseLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.baseLibrary.reset();
 });
 

--- a/test/cssVariablesLibrary.js
+++ b/test/cssVariablesLibrary.js
@@ -3,8 +3,7 @@ import test from 'ava';
 import rcs from '../lib';
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.cssVariablesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.cssVariablesLibrary.reset();
 });
 

--- a/test/files/results/css/style-with-config.css
+++ b/test/files/results/css/style-with-config.css
@@ -22,17 +22,17 @@
     content: 'block__element--modifier';
 }
 
-#f {
+#a {
     content: 'id';
 }
 
-.g[src] {
+.f[src] {
     content: 'attribute';
     filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
 
 @media screen and (min-width: .40em) {
-    #f {
+    #a {
         height: .20px;
         width: .20em;
     }
@@ -44,7 +44,7 @@
 @media screen and (min-width: 40em)
 
 {
-    #f
+    #a
     {
         height: .20px;
         width: .20em;

--- a/test/files/results/css/style.css
+++ b/test/files/results/css/style.css
@@ -1,24 +1,24 @@
-.b {
+.a {
     content: 'block';
 }
 
-.c {
+.b {
     content: 'block__element';
 }
 
-.d {
+.c {
     content: 'block__element--modifier';
 }
 
-.e{
+.d{
     content: 'block--modifier';
 }
 
-.f:before {
+.e:before {
     content: 'before';
 }
 
-.d {
+.c {
     content: 'block__element--modifier';
 }
 
@@ -26,7 +26,7 @@
     content: 'id';
 }
 
-.g[src] {
+.f[src] {
     content: 'attribute';
     filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
@@ -55,20 +55,20 @@ h1 {
     color: red;
 }
 
-.h {
+.g {
     content: 'reveal';
     color: #eee;
     font-size: .5rem;
 }
 
-.i.h {
+.h.g {
     content: 'js reveal';
 }
 
-.j.h {
+.i.g {
     content: 'js reveal';
 }
 
-.k {
+.j {
     content: 'js-reveal';
 }

--- a/test/files/results/css/style2.css
+++ b/test/files/results/css/style2.css
@@ -2,26 +2,26 @@
     content: 'id';
 }
 
-.c {
+.b {
     content: 'block__element';
 }
 
-.d {
+.c {
     content: 'block__element--modifier';
 }
 
-.d {
+.c {
     content: 'block__element--modifier';
 }
 
-.e{
+.d{
     content: 'block--modifier';
 }
 
-.b {
+.a {
     content: 'block';
 }
 
-.f:before {
+.e:before {
     content: 'before';
 }

--- a/test/files/results/css/subdirectory/style.css
+++ b/test/files/results/css/subdirectory/style.css
@@ -22,6 +22,6 @@
     content: 'before';
 }
 
-#f {
+#a {
     content: 'id';
 }

--- a/test/files/results/html/index.html
+++ b/test/files/results/html/index.html
@@ -5,7 +5,7 @@
     <title>Test Document</title>
 </head>
 <body>
+    <div class="a"></div>
     <div class="b"></div>
-    <div class="c"></div>
 </body>
 </html>

--- a/test/files/results/html/script.html
+++ b/test/files/results/html/script.html
@@ -7,17 +7,17 @@
   <title>Document</title>
 </head>
 <body>
-  <table class="b c" id="a"></table>
+  <table class="a b" id="a"></table>
   <div>
     <div>
       <div class="some-class">
-        <table class="b c" id="a"></table>
+        <table class="a b" id="a"></table>
       </div>
     </div>
   </div>
   <script>
-    const myClass = "c";
-    const anotherClass = "b";
+    const myClass = "b";
+    const anotherClass = "a";
     const id = "a";
   </script>
 </body>

--- a/test/files/results/js/complex.txt
+++ b/test/files/results/js/complex.txt
@@ -17,7 +17,7 @@ function firstDifferenceIndex(string1, string2) {
 /***/ (function(module, exports) {
 
 // removed by extract-text-webpack-plugin
-module.exports = {"table":"b","key":"f"};
+module.exports = {"table":"a","key":"e"};
 
 /***/ }),
 /* 523 */

--- a/test/files/results/js/main.txt
+++ b/test/files/results/js/main.txt
@@ -1,11 +1,11 @@
 // jQuery example
-$('.b');
+$('.a');
 
 // vanillaJS example
-document.getElementsByClassName('c');
-document.getElementById('d');
-document.getElementById(" d");
-document.getElementById('\n\n\t d   d');
+document.getElementsByClassName('b');
+document.getElementById('c');
+document.getElementById(" c");
+document.getElementById('\n\n\t c   c');
 
 angular.module('service.test');
 

--- a/test/files/results/js/react.txt
+++ b/test/files/results/js/react.txt
@@ -18,10 +18,10 @@ class Events extends Component {
 
   renderEvent() {
     if (this.props.events.length === 0) {
-      return <p class="b f">is</p>;
+      return <p class="a e">is</p>;
     }
 
-    return <ListView class="c" data={this.props.events} />;
+    return <ListView class="b" data={this.props.events} />;
   }
 
   render() {

--- a/test/files/results/pug/script.pug
+++ b/test/files/results/pug/script.pug
@@ -4,12 +4,12 @@ head
   meta(name!='viewport' content!='width=device-width, initial-scale=1.0')
   meta(http-equiv!='X-UA-Compatible' content!='ie=edge')
   title Document
-table#a.b.c
+table#a.a.b
 div
   div
     .some-class
-      table#a.b.c
+      table#a.a.b
 script.
-  const myClass = "c";
-  const anotherClass = "b";
+  const myClass = "b";
+  const anotherClass = "a";
   const id = "a";

--- a/test/fillLibraries.js
+++ b/test/fillLibraries.js
@@ -4,10 +4,10 @@ import rcs from '../lib';
 
 test.beforeEach(() => {
   // reset counter and selectors for tests
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
   rcs.selectorsLibrary.reset();
   rcs.keyframesLibrary.reset();
+  rcs.keyframesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
 });
 
 test('fillLibraries should fill all libraries', (t) => {
@@ -30,8 +30,8 @@ test('fillLibraries should fill all libraries', (t) => {
 
 
   t.is(rcs.keyframesLibrary.get('move'), 'a');
-  t.is(rcs.selectorsLibrary.get('id'), 'b');
-  t.is(rcs.selectorsLibrary.get('test'), 'c');
+  t.is(rcs.selectorsLibrary.get('id'), 'a');
+  t.is(rcs.selectorsLibrary.get('test'), 'a');
 });
 
 test('fillLibraries should fill all libraries with pre or suffixes', (t) => {
@@ -70,7 +70,7 @@ test('fillLibraries should fill classes from html', (t) => {
   );
 
   t.is(rcs.selectorsLibrary.get('id'), 'a');
-  t.is(rcs.selectorsLibrary.get('test'), 'b');
+  t.is(rcs.selectorsLibrary.get('test'), 'a');
 });
 
 
@@ -82,7 +82,7 @@ test('fillLibraries should fill classes from html with multiple style tags', (t)
     },
   );
 
-  t.is(rcs.selectorsLibrary.get('test'), 'b');
+  t.is(rcs.selectorsLibrary.get('test'), 'a');
   t.is(rcs.selectorsLibrary.get('id'), 'a');
-  t.is(rcs.selectorsLibrary.get('another-class'), 'c');
+  t.is(rcs.selectorsLibrary.get('another-class'), 'b');
 });

--- a/test/keyframesLibrary.js
+++ b/test/keyframesLibrary.js
@@ -3,8 +3,7 @@ import test from 'ava';
 import rcs from '../lib';
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.keyframesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.keyframesLibrary.reset();
 });
 

--- a/test/nameGenerator.js
+++ b/test/nameGenerator.js
@@ -1,21 +1,44 @@
 import test from 'ava';
 
-import rcs from '../lib';
+import { useCustomGenerator, NameGenerator } from '../lib/nameGenerator';
+
+let nameGenerator;
+
+test.beforeEach(() => {
+  nameGenerator = new NameGenerator();
+});
 
 test('generate new random name', (t) => {
-  t.is(rcs.nameGenerator.generate(), 't');
-  t.is(rcs.nameGenerator.generate(), 'n');
-  t.is(rcs.nameGenerator.nameCounter, 3);
+  t.is(nameGenerator.generate(), 't');
+  t.is(nameGenerator.generate(), 'n');
+  t.is(nameGenerator.nameCounter, 3);
 
-  rcs.nameGenerator.reset();
+  nameGenerator.reset();
 
-  t.is(rcs.nameGenerator.nameCounter, 1);
-  t.is(rcs.nameGenerator.generate(), 't');
+  t.is(nameGenerator.nameCounter, 1);
+  t.is(nameGenerator.generate(), 't');
 });
 
 test('generate another alphabet', (t) => {
-  rcs.nameGenerator.setAlphabet('#abc');
+  nameGenerator.setAlphabet('#abc');
 
-  t.is(rcs.nameGenerator.generate(), 'a');
+  t.is(nameGenerator.generate(), 'a');
 });
 
+test('use customNameGenerator', (t) => {
+  nameGenerator.setAlphabet('#abcd');
+
+  t.is(nameGenerator.generate(), 'a');
+
+  useCustomGenerator(() => 'custom');
+
+  t.is(nameGenerator.generate(), 'custom');
+
+  useCustomGenerator(() => 'another');
+
+  t.is(nameGenerator.generate(), 'another');
+
+  useCustomGenerator(null);
+
+  t.is(nameGenerator.generate(), 'd');
+});

--- a/test/replace.any.js
+++ b/test/replace.any.js
@@ -17,8 +17,7 @@ function replaceAnyMacro(t, input, expected, fillLibrary = '') {
 replaceAnyMacro.title = (providedTitle, input) => (!providedTitle ? input.trim() : providedTitle);
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
 });
 

--- a/test/replace.css.js
+++ b/test/replace.css.js
@@ -26,8 +26,9 @@ function replaceMultipleCssMacro(t, inputs, expects, options = {}) {
 }
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
+  rcs.keyframesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
+  rcs.cssVariablesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
   rcs.keyframesLibrary.reset();
   rcs.cssVariablesLibrary.reset();
@@ -164,11 +165,11 @@ test('should replace keyframes properly',
         from {} to {}
     }
 
-    .b {
+    .a {
         animation:a 4s;
     }
 
-    .c {
+    .b {
         animation:     a     4s;
     }
   `,
@@ -215,7 +216,7 @@ test('should replace keyframes properly in nested animations',
         from {} to {}
     }
 
-    .c {
+    .a {
         animation-name: a, b;
         animation:  a 4s infinite,
                     a 10s,
@@ -223,7 +224,7 @@ test('should replace keyframes properly in nested animations',
                     not-setted-keyframe 2s;
     }
 
-    .d {
+    .b {
         animation:     a     4s  , b 10s;
     }
   `,
@@ -263,21 +264,21 @@ test('should not replace keyframes properly',
 test('should replace keyframes properly in a oneliner',
   replaceCssMacro,
   '@keyframes  move {from {} to {}}.selector {animation: move 4s, move 4s infinite, do-not-trigger 10s infinite}.another-selector {animation:     move     4s    }',
-  '@keyframes  a {from {} to {}}.b {animation: a 4s, a 4s infinite, do-not-trigger 10s infinite}.c {animation:     a     4s    }',
+  '@keyframes  a {from {} to {}}.a {animation: a 4s, a 4s infinite, do-not-trigger 10s infinite}.b {animation:     a     4s    }',
   { replaceKeyframes: true },
 );
 
 test('should not replace keyframes percentage comas | issue #69',
   replaceCssMacro,
   '@keyframes  move {from {} 50.1% {} to {}}.selector {animation: move 4s}',
-  '@keyframes  a {from {} 50.1% {} to {}}.b {animation: a 4s}',
+  '@keyframes  a {from {} 50.1% {} to {}}.a {animation: a 4s}',
   { replaceKeyframes: true },
 );
 
 test('should replace keyframes with suffixes',
   replaceCssMacro,
   '@keyframes move {from {} to {}}.selector {animation: move 4s, move 4s infinite, do-not-trigger 10s infinite}.another-selector {animation: move 4s }',
-  '@keyframes a {from {} to {}}.b-suf {animation: a 4s, a 4s infinite, do-not-trigger 10s infinite}.c-suf {animation: a 4s }',
+  '@keyframes a {from {} to {}}.a-suf {animation: a 4s, a 4s infinite, do-not-trigger 10s infinite}.b-suf {animation: a 4s }',
   {
     replaceKeyframes: true,
     suffix: '-suf',
@@ -287,7 +288,7 @@ test('should replace keyframes with suffixes',
 test('should replace keyframes with prefixes',
   replaceCssMacro,
   '@keyframes move {from {} to {}}.selector {animation: move 4s, move 4s infinite, do-not-trigger 10s infinite}.another-selector {animation: move 4s }',
-  '@keyframes a {from {} to {}}.pre-b {animation: a 4s, a 4s infinite, do-not-trigger 10s infinite}.pre-c {animation: a 4s }',
+  '@keyframes a {from {} to {}}.pre-a {animation: a 4s, a 4s infinite, do-not-trigger 10s infinite}.pre-b {animation: a 4s }',
   {
     replaceKeyframes: true,
     prefix: 'pre-',
@@ -388,7 +389,7 @@ test('should replace css variables properly',
       --b: linear-gradient(var(--a), var(--bottom-color));
     }
 
-    #c {
+    #a {
       background-color: var(--a);
     }
   `,
@@ -447,19 +448,19 @@ test('should replace css variables',
     }
   `,
   `
-    .d {
+    .a {
       --a: #111;
       --b: #f0f0f0;
       --c: #999;
     }
 
-    .e {
+    .b {
       --a: red;
       --b: white;
       --c: black;
     }
 
-    .f {
+    .c {
       color: var(--a);
       background-color: var(--b);
       font-size: 1.2em;
@@ -495,7 +496,7 @@ test('replace css variables with fallbacks | issue rename-css-selectors#42',
       --c: pink;
     }
 
-    .d {
+    .a {
       border: var(--a, var(--b))
               solid
               var(--c, transparent);
@@ -528,7 +529,7 @@ test('replace css variables in calc and multiple variables | rename-css-selector
       --e: 0px;
     }
 
-    .f {
+    .a {
       margin-right: calc(var(--a, var(--e)) - var(--b, var(--e)));
       margin-bottom: calc(var(--c, var(--e)) - var(--d, var(--e)));
     }
@@ -558,7 +559,7 @@ test('replace css variables with deep nested and multiline | rename-css-selector
       --c: 2px;
     }
 
-    .d {
+    .a {
       margin: var(--a, var(--b))
               var(--b, var(--a, 3px))
               5px

--- a/test/replace.html.js
+++ b/test/replace.html.js
@@ -17,8 +17,8 @@ function replaceHtmlMacro(t, selectors, input, expected, options) {
 }
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
+  rcs.keyframesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
   rcs.keyframesLibrary.reset();
 });

--- a/test/replace.js.js
+++ b/test/replace.js.js
@@ -18,15 +18,15 @@ function replaceJsMacro(t, input, expected, fillLibrary = fs.readFileSync(path.j
 replaceJsMacro.title = (providedTitle, input) => (!providedTitle ? input.trim() : providedTitle);
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
+  rcs.cssVariablesLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
   rcs.cssVariablesLibrary.reset();
 });
 
 test(replaceJsMacro,
   'var test = \' something \';\nconst myClass = "jp-block";',
-  'var test = \' something \';\nconst myClass = "b";',
+  'var test = \' something \';\nconst myClass = "a";',
 );
 
 test(replaceJsMacro,
@@ -111,7 +111,7 @@ test('check "key" in object non replacement | issue #83',
 test('replace in template | issue #84',
   replaceJsMacro,
   'const templ = `<div class="jp-block" id="someid">`;',
-  'const templ = `<div class="b" id="a">`;',
+  'const templ = `<div class="a" id="a">`;',
   '.jp-block{}#someid{}',
 );
 

--- a/test/replace.pug.js
+++ b/test/replace.pug.js
@@ -19,8 +19,7 @@ function replacePugMacro(t, selectors, input, expected, options) {
 }
 
 test.beforeEach(() => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
 });
 

--- a/test/replace.string.js
+++ b/test/replace.string.js
@@ -3,8 +3,7 @@ import test from 'ava';
 import rcs from '../lib';
 
 test.beforeEach((t) => {
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
 
   // eslint-disable-next-line no-param-reassign
@@ -67,7 +66,7 @@ test('replace multiple strings', (t) => {
   rcs.selectorsLibrary.set('.test-2');
   rcs.selectorsLibrary.set('#lala');
 
-  const expectedString = '".a#c.b#chained still-here"';
+  const expectedString = '".a#a.b#chained still-here"';
   const replacedString = rcs.replace.string('".test#lala.test-2#chained still-here"', t.context.regex());
 
   t.is(replacedString, expectedString);

--- a/test/selectorsLibrary.js
+++ b/test/selectorsLibrary.js
@@ -5,8 +5,7 @@ import attributeLibrary from '../lib/attributeLibrary';
 
 test.beforeEach((t) => {
   // reset counter and selectors for tests
-  rcs.nameGenerator.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
-  rcs.nameGenerator.reset();
+  rcs.selectorsLibrary.setAlphabet('#abcdefghijklmnopqrstuvwxyz');
   rcs.selectorsLibrary.reset();
 
   // eslint-disable-next-line no-param-reassign
@@ -55,8 +54,8 @@ test('get | should get every single selectors', (t) => {
   const dotTestSelector = rcs.selectorsLibrary.get('.test');
   const testSelector = rcs.selectorsLibrary.get('test');
 
-  t.is(dotTestSelector, 'b');
-  t.is(testSelector, 'b');
+  t.is(dotTestSelector, 'a');
+  t.is(testSelector, 'a');
 });
 
 test('get | should get every single selectors with type char', (t) => {
@@ -65,8 +64,8 @@ test('get | should get every single selectors with type char', (t) => {
   const dotTestSelector = rcs.selectorsLibrary.get('.test', { addSelectorType: true });
   const testSelector = rcs.selectorsLibrary.get('test', { addSelectorType: true });
 
-  t.is(dotTestSelector, '.b');
-  t.is(testSelector, '.b');
+  t.is(dotTestSelector, '.a');
+  t.is(testSelector, '.a');
 });
 
 test('get | with pre- suffix', (t) => {
@@ -78,8 +77,8 @@ test('get | with pre- suffix', (t) => {
   const selector = rcs.selectorsLibrary.get('.test');
   const selectorWithType = rcs.selectorsLibrary.get('.test', { addSelectorType: true });
 
-  t.is(selector, 'pre-b-suf');
-  t.is(selectorWithType, '.pre-b-suf');
+  t.is(selector, 'pre-a-suf');
+  t.is(selectorWithType, '.pre-a-suf');
 });
 
 test('get | should not get excluded selector', (t) => {
@@ -100,7 +99,7 @@ test('get | extend true', (t) => {
   const dotTestSelector = rcs.selectorsLibrary.get('.test', { extend: true });
 
   t.is(typeof dotTestSelector, 'object');
-  t.is(dotTestSelector.compressedSelector, 'b');
+  t.is(dotTestSelector.compressedSelector, 'a');
   t.is(dotTestSelector.selector, 'test');
 });
 
@@ -108,10 +107,10 @@ test('get | insure no mix if using existing selector', (t) => {
   t.context.setSelectors();
 
   const testSelector = rcs.selectorsLibrary.get('test');
-  const aSelector = rcs.selectorsLibrary.get('b');
+  const aSelector = rcs.selectorsLibrary.get('a');
 
-  t.is(testSelector, 'b');
-  t.not(aSelector, 'b');
+  t.is(testSelector, 'a');
+  t.not(aSelector, 'a');
 });
 
 
@@ -126,7 +125,7 @@ test('getall | should return a regex of compressed with classes', (t) => {
     addSelectorType: true,
   });
 
-  t.is(regex.source, '(\\#a)|(\\.b|\\.c)');
+  t.is(regex.source, '(\\#a)|(\\.a|\\.b)');
 });
 
 test('getall | should return an array with selectors', (t) => {
@@ -139,10 +138,10 @@ test('getall | should return an array with selectors', (t) => {
   t.truthy(array['.test']);
   t.truthy(array['.jp-selector']);
 
+  t.falsy(array['.a']);
   t.falsy(array['.b']);
-  t.falsy(array['.c']);
 
-  t.is(array['.test'], 'b');
+  t.is(array['.test'], 'a');
 
   array = rcs.selectorsLibrary.getIdSelector().getAll({
     addSelectorType: true,
@@ -165,10 +164,10 @@ test('getall | should return an array with compressed selectors', (t) => {
   t.falsy(array['.test']);
   t.falsy(array['.jp-selector']);
 
+  t.truthy(array['.a']);
   t.truthy(array['.b']);
-  t.truthy(array['.c']);
 
-  t.is(array['.b'], 'test');
+  t.is(array['.a'], 'test');
 
   array = rcs.selectorsLibrary.getIdSelector().getAll({
     getRenamedValues: true,
@@ -196,7 +195,7 @@ test('getall | should return a regex of non compressed selecotrs', (t) => {
     getRenamedValues: true,
   });
 
-  t.is(regex.source, '((\\s|\\#)(a)[\\s)])|((\\s|\\.)(b|c)[\\s)])');
+  t.is(regex.source, '((\\s|\\#)(a)[\\s)])|((\\s|\\.)(a|b)[\\s)])');
 });
 
 test('getall | should return a regex of compressed selectors', (t) => {
@@ -216,7 +215,7 @@ test('getall | should get all extend', (t) => {
 
   t.is(typeof cssObject.test, 'object');
   t.is(cssObject.test.type, 'class');
-  t.is(cssObject.test.compressedSelector, 'b');
+  t.is(cssObject.test.compressedSelector, 'a');
 
   cssObject = rcs.selectorsLibrary.getIdSelector().getAll({
     extend: true,
@@ -236,7 +235,7 @@ test('getall | should get all extend with selectors', (t) => {
 
   t.is(typeof cssObject['.test'], 'object');
   t.is(cssObject['.test'].type, 'class');
-  t.is(cssObject['.test'].compressedSelector, 'b');
+  t.is(cssObject['.test'].compressedSelector, 'a');
 
   cssObject = rcs.selectorsLibrary.getIdSelector().getAll({
     addSelectorType: true,
@@ -257,9 +256,9 @@ test('getall | should get all normal with selectors', (t) => {
     extend: true,
   });
 
-  t.is(typeof cssObject['.b'], 'object');
-  t.is(cssObject['.b'].type, 'class');
-  t.is(cssObject['.b'].modifiedSelector, 'test');
+  t.is(typeof cssObject['.a'], 'object');
+  t.is(cssObject['.a'].type, 'class');
+  t.is(cssObject['.a'].modifiedSelector, 'test');
 
   cssObject = rcs.selectorsLibrary.getIdSelector().getAll({
     getRenamedValues: true,
@@ -278,8 +277,8 @@ test('getall | should get all setted classes', (t) => {
   let array = rcs.selectorsLibrary.getClassSelector().getAll();
 
   t.is(typeof array, 'object');
-  t.is(array.test, 'b');
-  t.is(array['jp-selector'], 'c');
+  t.is(array.test, 'a');
+  t.is(array['jp-selector'], 'b');
 
   array = rcs.selectorsLibrary.getIdSelector().getAll();
   t.is(array.id, 'a');
@@ -293,8 +292,8 @@ test('getall | should get all setted compressed classes', (t) => {
   });
 
   t.is(typeof array, 'object');
-  t.is(array.b, 'test');
-  t.is(array.c, 'jp-selector');
+  t.is(array.a, 'test');
+  t.is(array.b, 'jp-selector');
 
   array = rcs.selectorsLibrary.getIdSelector().getAll({
     getRenamedValues: true,
@@ -359,9 +358,9 @@ test('set | should set values out of an array', (t) => {
   ]);
 
   // should be set
-  t.is(rcs.selectorsLibrary.getClassSelector().values.test, 'b');
+  t.is(rcs.selectorsLibrary.getClassSelector().values.test, 'a');
   t.is(rcs.selectorsLibrary.getIdSelector().values.id, 'a');
-  t.is(rcs.selectorsLibrary.getClassSelector().values['jp-selector'], 'c');
+  t.is(rcs.selectorsLibrary.getClassSelector().values['jp-selector'], 'b');
 
   // should not be set
   t.falsy(rcs.selectorsLibrary.getClassSelector().values['not-set']);


### PR DESCRIPTION
This is based on #64, but completely reworked on top of #91.

There is now a name generator instance per BaseLibrary instance, so there is plenty more selectors to create.
This requires an major version bump, since the API evolved.

