### PR TITLE
Fix selector mismatch

### DIFF
--- a/docs/api/usecustomgenerator.md
+++ b/docs/api/usecustomgenerator.md
@@ -1,0 +1,30 @@
+# rcs.useCustomGenerator
+
+> This is a special method if you want to generate different selectors
+
+**useCustomGenerator(customGenerator)**
+
+Parameters:
+- customGenerator `<Function>`: This function parameter is an object containing:
+
+* `selector`: The initial selector for generating
+* `nameCounter`: An increasing number
+* `alphabet`: The alphabet used as default parameters
+* `type`: The library type calling the generator (any of `id`, `class`, `keyframe`, `variable`, `attribute`). 
+
+It should return a unique string which will then be used as selector.
+
+## Usage
+
+Example:
+
+```js
+const { useCustomGenerator } = require('rcs-core/nameGenerator');
+const uniqueStrings = require('some-unique-naming-lib');
+
+useCustomGenerator((Obj) => (
+  uniqueStrings(Obj.nameCounter)
+));
+
+const newName = rcs.nameGenerator.generate(); // does not return 'a' but the outcome from `uniqueStrings(nameCounter)`
+```

--- a/lib/attributeLibrary.js
+++ b/lib/attributeLibrary.js
@@ -15,6 +15,11 @@ export class AttributeLibrary extends BaseLibrary {
     this.attributeSelectors = {};
   }
 
+  // used at many place, let make a single function for this
+  static isSelector(selector) {
+    return selector.charAt(0) === '.' || selector.charAt(0) === '#';
+  }
+
   static removePseudoElements(value) {
     const splits = value.split(/\\/g);
     const splittedEscapes = splits.map((split, i) => {
@@ -102,7 +107,7 @@ export class AttributeLibrary extends BaseLibrary {
       }
     }
 
-    if (repObj.renamedValue !== undefined && (repObj.renamedValue.charAt(0) === '.' || repObj.renamedValue.charAt(0) === '#')) {
+    if (repObj.renamedValue !== undefined && AttributeLibrary.isSelector(repObj.renamedValue)) {
       // eslint-disable-next-line no-param-reassign
       repObj.renamedValue = repObj.renamedValue.slice(1, repObj.renamedValue.length);
     }

--- a/lib/baseLibrary.js
+++ b/lib/baseLibrary.js
@@ -252,6 +252,10 @@ export class BaseLibrary {
   }
 
   isExcluded(string) {
+    if (string === '__proto__') {
+      // Since this.values['__proto__'] always exists, we mustn't accept this as a renaming
+      return true;
+    }
     if (includes(this.excludes, string)) {
       return true;
     }

--- a/lib/replace/any.js
+++ b/lib/replace/any.js
@@ -11,7 +11,7 @@ const replaceAny = (code, opts = {}) => {
     return data;
   }
 
-  data = data.replace(replaceRegex.strings, match => replaceString(match, regex, ' ', opts));
+  data = data.replace(replaceRegex.strings, match => replaceString(match, regex, opts));
 
   return data;
 };

--- a/lib/replace/js.js
+++ b/lib/replace/js.js
@@ -46,6 +46,8 @@ const replaceJs = (code, espreeOptions) => {
     },
   });
 
+  const isJSX = options.ecmaFeatures.jsx;
+
   traverse(ast, {
     pre: (node) => {
       // Avoid recursing into a "in" node since it can't be a CSS class or variable.
@@ -62,7 +64,8 @@ const replaceJs = (code, espreeOptions) => {
           const selectorLib = p1 === 'class' ? selectorsLibrary.getClassSelector()
                                              : selectorsLibrary.getIdSelector();
           const replacedAttr = newValue.replace(newValue, match =>
-            replaceString(match, selectorLib.getAll({ regex: true }), ' ', { countStats: false, source }));
+            replaceString(match, selectorLib.getAll({ regex: true }),
+                          { isJSX, countStats: false, source }));
           // eslint-disable-next-line
           return p1 + '=' + p2 + replacedAttr.slice(1, replacedAttr.length - 1) + p2;
         });
@@ -72,17 +75,19 @@ const replaceJs = (code, espreeOptions) => {
       } else if (node.type === 'Literal' && typeof node.value === 'string') {
         const source = makeSource(node, options.sourceFile);
         // eslint-disable-next-line no-param-reassign
-        node.raw = node.raw.replace(node.raw, match => replaceString(match, regex, ' ', { source }));
+        node.raw = node.raw.replace(node.raw,
+                    match => replaceString(match, regex, { isJSX, source }));
 
         // add whitespaces before and after
         // to make the regex work
         const newValue = ` ${node.value} `;
         // replace css selectors
-        const replacedCssSelectors = newValue.replace(newValue, match => replaceString(match, regex, ' ', { countStats: false, source }));
+        const replacedCssSelectors = newValue.replace(newValue, match =>
+          replaceString(match, regex, { isJSX, countStats: false, source }));
         // replace css variables
-        const replacedCssVariables = replacedCssSelectors.replace(allRegex.cssVariables, match => (
-          cssVariablesLibrary.get(match, { source })
-        ));
+        const replacedCssVariables = replacedCssSelectors.replace(allRegex.cssVariables,
+          match => (cssVariablesLibrary.get(match, { source })),
+        );
 
         // eslint-disable-next-line no-param-reassign
         node.value = replacedCssVariables.slice(1, replacedCssVariables.length - 1);

--- a/lib/replace/js.js
+++ b/lib/replace/js.js
@@ -65,10 +65,10 @@ const replaceJs = (code, espreeOptions) => {
                                              : selectorsLibrary.getIdSelector();
           const replacedAttr = newValue.replace(newValue, match =>
             replaceString(match, selectorLib.getAll({ regex: true }),
-              // don't be too smart about selector detection and non replacement if we have 
-              // a class, since class="a b" should replace both entry here even if it looks like 
+              // don't be too smart about selector detection and non replacement if we have
+              // a class, since class="a b" should replace both entry here even if it looks like
               // a selector text for parent child tags
-                          { isJSX: p1 === 'class' || isJSX, countStats: false, source }));
+                          { isJSX, classOnly: p1 === 'class', countStats: false, source }));
           // eslint-disable-next-line
           return p1 + '=' + p2 + replacedAttr.slice(1, replacedAttr.length - 1) + p2;
         });

--- a/lib/replace/js.js
+++ b/lib/replace/js.js
@@ -65,7 +65,10 @@ const replaceJs = (code, espreeOptions) => {
                                              : selectorsLibrary.getIdSelector();
           const replacedAttr = newValue.replace(newValue, match =>
             replaceString(match, selectorLib.getAll({ regex: true }),
-                          { isJSX, countStats: false, source }));
+              // don't be too smart about selector detection and non replacement if we have 
+              // a class, since class="a b" should replace both entry here even if it looks like 
+              // a selector text for parent child tags
+                          { isJSX: p1 === 'class' || isJSX, countStats: false, source }));
           // eslint-disable-next-line
           return p1 + '=' + p2 + replacedAttr.slice(1, replacedAttr.length - 1) + p2;
         });

--- a/lib/replace/regex.js
+++ b/lib/replace/regex.js
@@ -7,4 +7,5 @@ export default {
   keyframes: /@(-[a-z]*-)*keyframes\s+([a-zA-Z0-9_-]+)/g, // matches keyframes and just the first group the first matched non-whitespace characters - e.g. matches: `@keyframes    my-KeyFra_me`
   cssVariables: /var\(\s*(--[^,\s]+?)(?:\s*,\s*(.+))?\s*\)/g, // matches everything inside `var(match)` - e.g. var(my-variable)
   templateSelectors: /(class|for|id)+\s*=\s*(['"])((?:.(?!\2))*.?)\2/g, // matches class="xyz", for="xyz" and id='xyz' in template node, first is "class" or "for" or "id", second is the quote type and last is the class names or id
+  likelySelector: /[ #.=,()"'[\]]+/, // if it contains any of these chars, then the string is likely a selector
 };

--- a/lib/replace/string.js
+++ b/lib/replace/string.js
@@ -22,21 +22,23 @@ const replaceString = (string, regex, options) => {
     surelySelector = false;
   }
 
-  const bastardSplitChars = '=,()"\'\\]';
-  let stringArray = tempString.split(new RegExp(`(?=[#. ${bastardSplitChars}])`));
+  const bastardSplitChars = ' =,()"\'\\]';
+  let stringArray = tempString.split(new RegExp(`(?=[#.${bastardSplitChars}])`));
   let previousEqual = false;
+  let previousAttr = '';
 
   // replace every single entry
   stringArray = stringArray.map((element) => {
-    if (element.length === 0 || element.trim().length === 0) {
+    // because we are using non-capturing split, the split char is kept as the first char
+    const interestingValue = element.replace(new RegExp(bastardSplitChars, 'g'), '');
+    if (interestingValue.length === 0) {
       return element;
     }
-
     // remember last iteration state before it's overwritten
     let prevEqual = previousEqual;
     previousEqual = element === '=';
 
-    const startSplitChar = (`${bastardSplitChars} `).indexOf(element.charAt(0))
+    const startSplitChar = bastardSplitChars.indexOf(element.charAt(0))
                               === -1 ? '' : element.charAt(0);
     const tempElement = element.slice(startSplitChar.length, element.length);
     if (tempElement.length === 0) {
@@ -46,7 +48,18 @@ const replaceString = (string, regex, options) => {
 
     const startWithSelector = AttributeLibrary.isSelector(tempElement);
     prevEqual = prevEqual || startSplitChar === '=';
-    if (surelySelector && !startWithSelector && !prevEqual) {
+
+    // if we had "div[attr=something", react only if attr is a class, id or for
+    // element will contain "div[attr" or " attr", we only care about the attribute name
+    let previousAttributeName = (!startWithSelector && prevEqual) ?
+                                    previousAttr.match(/[^a-zA-Z]+([a-zA-Z]+)/) : null;
+    previousAttributeName = previousAttributeName !== null ? previousAttributeName[1] : null;
+    const isAttributeInteresting = previousAttributeName === 'class'
+                                || previousAttributeName === 'id'
+                                || previousAttributeName === 'for';
+
+    previousAttr = interestingValue;
+    if (surelySelector && !startWithSelector && (!prevEqual || !isAttributeInteresting)) {
       // expecting a selector, but got a tag name, let's return it unmodified
       // except for "class=" or "id=" or "for="
       return startSplitChar + tempElement;

--- a/lib/replace/string.js
+++ b/lib/replace/string.js
@@ -14,12 +14,20 @@ const replaceString = (string, regex, options) => {
   // remove the string characters
   tempString = tempString.slice(1, tempString.length - 1);
 
+  let selectorLib = selectorsLibrary;
   // detect if it's a selector
   let surelySelector = tempString.match(regexp.likelySelector) !== null;
   if (options && options.isJSX) {
     // with JSX, you can have code in JS that contains HTML's attribute directly so we
     // can't say if it is a selector in case like 'if (something) return <div class="a b">;'
     surelySelector = false;
+  }
+
+  if (options && (options.classOnly !== undefined)) {
+    surelySelector = false;
+    // if we know that it's a class or an id, let's only search those
+    selectorLib = options.classOnly ? selectorsLibrary.getClassSelector()
+                                    : selectorsLibrary.getIdSelector();
   }
 
   const bastardSplitChars = ' =,()"\'\\]';
@@ -64,7 +72,7 @@ const replaceString = (string, regex, options) => {
       // except for "class=" or "id=" or "for="
       return startSplitChar + tempElement;
     }
-    return startSplitChar + selectorsLibrary.get(tempElement,
+    return startSplitChar + selectorLib.get(tempElement,
               merge({ addSelectorType: startWithSelector }, options));
   });
 

--- a/lib/replace/string.js
+++ b/lib/replace/string.js
@@ -1,6 +1,9 @@
+import merge from 'lodash.merge';
 import selectorsLibrary from '../selectorsLibrary';
+import { AttributeLibrary } from '../attributeLibrary';
+import regexp from './regex';
 
-const replaceString = (string, regex, splitter = ' ', options) => {
+const replaceString = (string, regex, options) => {
   let result;
   let tempString = string;
 
@@ -11,45 +14,48 @@ const replaceString = (string, regex, splitter = ' ', options) => {
   // remove the string characters
   tempString = tempString.slice(1, tempString.length - 1);
 
-  let stringArray = tempString.split(splitter);
+  // detect if it's a selector
+  let surelySelector = tempString.match(regexp.likelySelector) !== null;
+  if (options && options.isJSX) {
+    // with JSX, you can have code in JS that contains HTML's attribute directly so we
+    // can't say if it is a selector in case like 'if (something) return <div class="a b">;'
+    surelySelector = false;
+  }
+
+  const bastardSplitChars = '=,()"\'\\]';
+  let stringArray = tempString.split(new RegExp(`(?=[#. ${bastardSplitChars}])`));
+  let previousEqual = false;
 
   // replace every single entry
   stringArray = stringArray.map((element) => {
-    if (element.length === 0) {
+    if (element.length === 0 || element.trim().length === 0) {
       return element;
     }
 
-    let tempElement = element;
+    // remember last iteration state before it's overwritten
+    let prevEqual = previousEqual;
+    previousEqual = element === '=';
 
-    // eslint-disable-next-line consistent-return
-    ['.', '#', ','].forEach((toSplit) => {
-      if (element.indexOf(toSplit) > '-1') {
-        tempElement = replaceString(`'${tempElement}'`, regex, toSplit);
-        tempElement = tempElement.slice(1, tempElement.length - 1);
+    const startSplitChar = (`${bastardSplitChars} `).indexOf(element.charAt(0))
+                              === -1 ? '' : element.charAt(0);
+    const tempElement = element.slice(startSplitChar.length, element.length);
+    if (tempElement.length === 0) {
+      // two comma can be merged in one
+      return startSplitChar;
+    }
 
-        return tempElement;
-      }
-    });
-
-    // add whitespace at the beginning and the end
-    tempElement = ` ${tempElement} `;
-
-    tempElement = tempElement.replace(regex, (match) => {
-      const matchBeginChar = match.charAt(0);
-      const matchEndChar = match.charAt(match.length - 1);
-
-      const toGet = match.slice(1, match.length - 1);
-
-      return matchBeginChar + selectorsLibrary.get(toGet, options) + matchEndChar;
-    });
-
-    // remove the string characters
-    tempElement = tempElement.slice(1, tempElement.length - 1);
-
-    return tempElement;
+    const startWithSelector = AttributeLibrary.isSelector(tempElement);
+    prevEqual = prevEqual || startSplitChar === '=';
+    if (surelySelector && !startWithSelector && !prevEqual) {
+      // expecting a selector, but got a tag name, let's return it unmodified
+      // except for "class=" or "id=" or "for="
+      return startSplitChar + tempElement;
+    }
+    return startSplitChar + selectorsLibrary.get(tempElement,
+              merge({ addSelectorType: startWithSelector }, options));
   });
 
-  result = stringArray.join(splitter);
+  result = stringArray.join('');
 
   // add the string characters
   result = beginChar + result + endChar;

--- a/lib/replace/string.js
+++ b/lib/replace/string.js
@@ -38,8 +38,13 @@ const replaceString = (string, regex, options) => {
   // replace every single entry
   stringArray = stringArray.map((element) => {
     // because we are using non-capturing split, the split char is kept as the first char
-    const interestingValue = element.replace(new RegExp(bastardSplitChars, 'g'), '');
+    const interestingValue = element.replace(new RegExp(`[${bastardSplitChars}]`, 'g'), '');
     if (interestingValue.length === 0) {
+      // remember that's we've seen a = just before, so for example 'div[ class = "test"]'
+      // will be split as 'div[ ', ' class', ' ', '=', ' ', '"test', ']'
+      // when we reach the space after the equal sign, we'll get here
+      // we should not change anything to the previousEqual state in that case
+      if (element === '=') previousEqual = true;
       return element;
     }
     // remember last iteration state before it's overwritten
@@ -49,11 +54,6 @@ const replaceString = (string, regex, options) => {
     const startSplitChar = bastardSplitChars.indexOf(element.charAt(0))
                               === -1 ? '' : element.charAt(0);
     const tempElement = element.slice(startSplitChar.length, element.length);
-    if (tempElement.length === 0) {
-      // two comma can be merged in one
-      return startSplitChar;
-    }
-
     const startWithSelector = AttributeLibrary.isSelector(tempElement);
     prevEqual = prevEqual || startSplitChar === '=';
 

--- a/lib/selectorsLibrary.js
+++ b/lib/selectorsLibrary.js
@@ -1,4 +1,5 @@
 import merge from 'lodash.merge';
+import { AttributeLibrary } from './attributeLibrary';
 import idSelectorLibrary from './idSelectorLibrary';
 import classSelectorLibrary from './classSelectorLibrary';
 
@@ -104,7 +105,7 @@ class SelectorsLibrary {
   }
 
   get(value, opts = {}) {
-    const hasType = (value.charAt(0) === '.' || value.charAt(0) === '#');
+    const hasType = AttributeLibrary.isSelector(value);
     if (!hasType) {
       const ret = this.selectors[0].get(value, opts);
       return ret === value ? this.selectors[1].get(value, opts) : ret;

--- a/test/files/results/js/main.txt
+++ b/test/files/results/js/main.txt
@@ -4,8 +4,8 @@ $('.a');
 // vanillaJS example
 document.getElementsByClassName('b');
 document.getElementById('c');
-document.getElementById(" c");
-document.getElementById('\n\n\t c   c');
+document.getElementById(" jp-block__element--modifier");
+document.getElementById('\n\n\t jp-block__element--modifier   jp-block__element--modifier');
 
 angular.module('service.test');
 

--- a/test/replace.js.js
+++ b/test/replace.js.js
@@ -122,6 +122,20 @@ test('replace in template | more complex',
   '.jp-block{}.jp-pseudo{}#someid{}',
 );
 
+test('replace in template | with class for id',
+  replaceJsMacro,
+  'const templ = `<div class="jp-block jp-pseudo" id="jp-block">`;',
+  'const templ = `<div class="a b" id="jp-block">`;',
+  '.jp-block{}.jp-pseudo{}#someid{}',
+);
+
+test('replace in template | with id for class',
+  replaceJsMacro,
+  'const templ = `<div class="someid jp-pseudo" id="someid">`;',
+  'const templ = `<div class="someid b" id="a">`;',
+  '.jp-block{}.jp-pseudo{}#someid{}',
+);
+
 
 test('replace css variables | issue rename-css-selectors#38',
   replaceJsMacro,

--- a/test/replace.js.js
+++ b/test/replace.js.js
@@ -115,6 +115,14 @@ test('replace in template | issue #84',
   '.jp-block{}#someid{}',
 );
 
+test('replace in template | more complex',
+  replaceJsMacro,
+  'const templ = `<div class="jp-block jp-pseudo" id="someid">`;',
+  'const templ = `<div class="a b" id="a">`;',
+  '.jp-block{}.jp-pseudo{}#someid{}',
+);
+
+
 test('replace css variables | issue rename-css-selectors#38',
   replaceJsMacro,
   `

--- a/test/replace.string.js
+++ b/test/replace.string.js
@@ -33,6 +33,11 @@ test('replace text correctly', (t) => {
     rcs.replace.string('\'   test \'', t.context.regex()),
     '\'   test \'',
   );
+
+  t.is(
+    rcs.replace.string('" ]test"', t.context.regex()),
+    '" ]test"',
+  );
 });
 
 test('replace multiple selectors', (t) => {

--- a/test/replace.string.js
+++ b/test/replace.string.js
@@ -90,6 +90,16 @@ test('replace more complex string', (t) => {
   expectedString = 'div[class="a"]';
 
   t.is(replacedString, expectedString);
+
+  replacedString = rcs.replace.string('div[name="test"]', t.context.regex());
+  expectedString = 'div[name="test"]';
+
+  t.is(replacedString, expectedString);
+
+  replacedString = rcs.replace.string('"test="', t.context.regex());
+  expectedString = '"test="';
+
+  t.is(replacedString, expectedString);
 });
 
 test('replace multiple strings', (t) => {

--- a/test/replace.string.js
+++ b/test/replace.string.js
@@ -15,12 +15,23 @@ test('replace text correctly', (t) => {
 
   t.is(
     rcs.replace.string('"   test "', t.context.regex()),
-    '"   a "',
+    '"   test "',
   );
 
   t.is(
+    rcs.replace.string('"   .test "', t.context.regex()),
+    '"   .a "',
+  );
+
+  t.is(
+    rcs.replace.string('"test"', t.context.regex()),
+    '"a"',
+  );
+
+
+  t.is(
     rcs.replace.string('\'   test \'', t.context.regex()),
-    '\'   a \'',
+    '\'   test \'',
   );
 });
 
@@ -28,10 +39,15 @@ test('replace multiple selectors', (t) => {
   rcs.selectorsLibrary.set('.test');
   rcs.selectorsLibrary.set('.my-div');
 
-  const expectedString = '"   a  none b "';
-  const replacedString = rcs.replace.string('"   test  none my-div "', t.context.regex());
+  const initialString = '"   test  none my-div "';
+  const replacedString = rcs.replace.string(initialString, t.context.regex());
 
-  t.is(replacedString, expectedString);
+  t.is(replacedString, initialString);
+
+  t.is(
+    rcs.replace.string('"   .test  none .my-div "', t.context.regex()),
+    '"   .a  none .b "',
+  );
 });
 
 test('replace id', (t) => {
@@ -55,8 +71,23 @@ test('replace class', (t) => {
 test('replace more complex string', (t) => {
   rcs.selectorsLibrary.set('.test');
 
-  const replacedString = rcs.replace.string('"[role="menu"] li:not(.test) a, [role="listbox"] li:not(.test) a"', t.context.regex());
-  const expectedString = '"[role="menu"] li:not(.a) a, [role="listbox"] li:not(.a) a"';
+  let replacedString = rcs.replace.string('"[role="menu"] li:not(.test) a, [role="listbox"] li:not(.test) a"', t.context.regex());
+  let expectedString = '"[role="menu"] li:not(.a) a, [role="listbox"] li:not(.a) a"';
+
+  t.is(replacedString, expectedString);
+
+  replacedString = rcs.replace.string('"div[class=\'test\']"', t.context.regex());
+  expectedString = '"div[class=\'a\']"';
+
+  t.is(replacedString, expectedString);
+
+  replacedString = rcs.replace.string('"div[class=test]"', t.context.regex());
+  expectedString = '"div[class=a]"';
+
+  t.is(replacedString, expectedString);
+
+  replacedString = rcs.replace.string('div[class="test"]', t.context.regex());
+  expectedString = 'div[class="a"]';
 
   t.is(replacedString, expectedString);
 });
@@ -75,6 +106,15 @@ test('replace multiple strings', (t) => {
 test('does not replace the text', (t) => {
   const expectedString = '"   test "';
   const replacedString = rcs.replace.string('"   test "', t.context.regex());
+
+  t.is(replacedString, expectedString);
+});
+
+test('replace multiple selectors', (t) => {
+  rcs.selectorsLibrary.set('.test');
+
+  const expectedString = '" #test .a "';
+  const replacedString = rcs.replace.string('" #test .test "', t.context.regex());
 
   t.is(replacedString, expectedString);
 });

--- a/test/stats.js
+++ b/test/stats.js
@@ -10,7 +10,7 @@ test.beforeEach(() => {
 
 test('replace js and get correct classes', (t) => {
   rcs.selectorsLibrary.fillLibrary('#id {} .selector {} .not-used {} .used {}');
-  rcs.replace.js('var a = \'selector used id\';');
+  rcs.replace.js('var a = \'.selector .used #id\';');
 
   const stats = rcs.stats();
 
@@ -20,7 +20,7 @@ test('replace js and get correct classes', (t) => {
 
 test('replace js and get correct classes and ids', (t) => {
   rcs.selectorsLibrary.fillLibrary('#id {} .selector {} .not-used {} .used {}');
-  rcs.replace.js('var a = "selector used";');
+  rcs.replace.js('var a = ".selector .used";');
 
   const stats = rcs.stats();
 


### PR DESCRIPTION
This should fix #93 and #51.
That's a WIP that depends on the other PR to be merged first (please look at the last 2 commits only, all previous commits are from other PR)

I've added some tests that were initially failing with former code and rewrote the `replace/string` code to make the logic more robust to get them passing.

Few remarks to understand the code:
1. Whenever calling DOM selector API in JS, you'll need to pass a string that contains CSS selectors.
2. The only methods you can call in JS for selecting DOM elements (like `getElementById`, `getElementsByClassName`, `getElementsByTagName`) expect exact value string, so no `: myId` but `:myId` (without space). If you call `getElementById(' myId')` it'll fail to fetch the element with `id='myId'`, and id attribute in HTML can not contains space. Similarly, for classes, any leading space is trimmed.

While knowing this, one could expect a JS string to be a selector if it contains some specific chars (like `.,=['` etc...).

Said simply: **if it looks like a selector, then it probably is**. And when we know it's a selector, we can dismiss invalid cases much more easily.

So the new code took that assumption, and it splits the input string to be replaced in an array using any selector specific chars.
If it doesn't find any, then it's querying `IdSelector` first and then `ClassSelector` (this is bogus, since we could mix one with the other here, but without runtime codeflow analysis, it's impossible to solve).
Yet, most JS code will use selectors based string and those will be correctly redirected to appropriate libraries.

So, I'd say that for most cases it's safe (at least, it's much safer than previous code that was even mixing strings with selectors prefix in them). 

They is one exception through: 
1. JSX code create "special" strings where it's impossible to solve so we assume we always have selectors in that case. For example, in such code:
```js
if (someCond) {
   return <div class='some stuff'/>;
}
```
We only receive `'some stuff'` to replace/rename in the current logic, so it appears like a CSS selector looking for a tag `stuff` in a tag `some`. Yet, since JSX option is on, it'll still query the IdSelector and ClassSelector like it did before. This means that if you have a id with `some=>a` and a class with `some=>t` (or no class with `some`) you'll get a replacement to `a` (like previous code).


## Previous inputs that were failing and is now correctly mapped
```css
CSS:
.test{}
```
```js
JS:
var t = '#test .test'; // replaced to '#test .a' now
```

```js
document.getElementById('test'); // wrongly replaced to 'a' as previously, but impossible to solve
document.getElementById(' test'); // kept as ' test', previously replaced by ' a'
```

```js
var t = 'input[name=test]'; // not replaced now, previously replaced by 'input[name=a]'
```

```js
var t = 'test='; // not replaced now, previously replaced by 'a='
```

I think, it would be a good idea to instruct the users to use `querySelector` et consort instead of the old DOM methods when using this library, since this API is 100% safe for rcs-core. 