### PR TITLE
Rework attribute selector to fix #96

### DIFF
--- a/lib/attributeLibrary.js
+++ b/lib/attributeLibrary.js
@@ -277,16 +277,21 @@ export class AttributeLibrary extends BaseLibrary {
 
     // then, we need to replace any original selector that would be matching this rule with a
     // rename that still match the replacement
-    // this.values.forEach(key => {
-
-    // });
+    Object.keys(this.values).forEach((key) => {
+      const r = AttributeLibrary.replaceAnAttributeSelector(false,
+                attributeSelectorKey, this.attributeSelectors[attributeSelectorKey], key);
+      if (r !== false) {
+        const prev = this.values[key];
+        this.values[key] = r;
+        delete this.compressedValues[prev];
+        this.compressedValues[r] = key;
+      }
+    });
   } // /setAttributeSelector
 
-  static replaceAnAttributeSelector(result, entry, slicedSelector) {
+  static replaceAnAttributeSelector(result, attributeSelector, value, slicedSelector) {
     if (result !== false) return result;
 
-    const attributeSelector = entry[0];
-    const value = entry[1];
     const attributeString = attributeSelector.slice(1, attributeSelector.length);
 
     if (attributeSelector.charAt(0) === '|') {
@@ -345,8 +350,8 @@ export class AttributeLibrary extends BaseLibrary {
 
     const slicedSelector = selector.replace(/^[.#]/, '');
 
-    return entries(this.attributeSelectors).reduce(
-      (a, entry) => AttributeLibrary.replaceAnAttributeSelector(a, entry, slicedSelector),
+    return entries(this.attributeSelectors).reduce((a, entry) =>
+      AttributeLibrary.replaceAnAttributeSelector(a, entry[0], entry[1], slicedSelector),
       false);
   } // /replaceAttributeSelector
 }

--- a/lib/attributeLibrary.js
+++ b/lib/attributeLibrary.js
@@ -274,72 +274,80 @@ export class AttributeLibrary extends BaseLibrary {
       regexType: attributeSelectorType,
       nameGeneratorCounter: new NameGenerator('attribute'),
     };
+
+    // then, we need to replace any original selector that would be matching this rule with a
+    // rename that still match the replacement
+    // this.values.forEach(key => {
+
+    // });
   } // /setAttributeSelector
 
-  replaceAttributeSelector(selector) {
-    let result = false;
+  static replaceAnAttributeSelector(result, entry, slicedSelector) {
+    if (result !== false) return result;
 
-    if (!this.isValidSelector(selector)) {
-      return result;
+    const attributeSelector = entry[0];
+    const value = entry[1];
+    const attributeString = attributeSelector.slice(1, attributeSelector.length);
+
+    if (attributeSelector.charAt(0) === '|') {
+      let match = slicedSelector.match(`^${attributeString}-`);
+
+      if (match) {
+        match = match[0].replace(/-$/, '');
+        return `${match}-${value.nameGeneratorCounter.generate(slicedSelector)}`;
+      }
     }
 
-    // const firstChar = selector.match(/^[.#]/) ? selector.charAt(0) : '';
-    const slicedSelector = selector.replace(/^[.#]/, '');
+    if (attributeSelector.charAt(0).match(/^[=~|]/)) {
+      const match = slicedSelector.match(attributeString);
 
-    entries(this.attributeSelectors).forEach((entry) => {
-      const attributeSelector = entry[0];
-      const value = entry[1];
-      const attributeString = attributeSelector.slice(1, attributeSelector.length);
-
-      if (attributeSelector.charAt(0) === '|') {
-        let match = slicedSelector.match(`^${attributeString}-`);
-
-        if (match) {
-          match = match[0].replace(/-$/, '');
-          result = `${match}-${value.nameGeneratorCounter.generate(slicedSelector)}`;
-        }
+      if (match && slicedSelector === match[0]) {
+        return match[0];
       }
+    }
 
-      if (attributeSelector.charAt(0).match(/^[=~|]/)) {
+    switch (attributeSelector.charAt(0)) {
+      case '*': {
         const match = slicedSelector.match(attributeString);
 
-        if (match && slicedSelector === match[0]) {
-          result = match[0];
+        if (match) {
+          return value.nameGeneratorCounter.generate(slicedSelector) +
+                   match[0] +
+                   value.nameGeneratorCounter.generate(slicedSelector);
         }
+        break;
       }
+      case '^': {
+        const match = slicedSelector.match(`^${attributeString}`);
 
-      switch (attributeSelector.charAt(0)) {
-        case '*': {
-          const match = slicedSelector.match(attributeString);
-
-          if (match) {
-            result = value.nameGeneratorCounter.generate(slicedSelector) +
-                     match[0] +
-                     value.nameGeneratorCounter.generate(slicedSelector);
-          }
-          break;
+        if (match) {
+          return match[0] + value.nameGeneratorCounter.generate(slicedSelector);
         }
-        case '^': {
-          const match = slicedSelector.match(`^${attributeString}`);
-
-          if (match) {
-            result = match[0] + value.nameGeneratorCounter.generate(slicedSelector);
-          }
-          break;
-        }
-        case '$': {
-          const match = slicedSelector.match(`${attributeString}$`);
-
-          if (match) {
-            result = value.nameGeneratorCounter.generate(slicedSelector) + match[0];
-          }
-          break;
-        }
-        default: break;
+        break;
       }
-    });
+      case '$': {
+        const match = slicedSelector.match(`${attributeString}$`);
 
-    return result;
+        if (match) {
+          return value.nameGeneratorCounter.generate(slicedSelector) + match[0];
+        }
+        break;
+      }
+      default: break;
+    }
+    return false;
+  }
+
+  replaceAttributeSelector(selector) {
+    if (!this.isValidSelector(selector)) {
+      return false;
+    }
+
+    const slicedSelector = selector.replace(/^[.#]/, '');
+
+    return entries(this.attributeSelectors).reduce(
+      (a, entry) => AttributeLibrary.replaceAnAttributeSelector(a, entry, slicedSelector),
+      false);
   } // /replaceAttributeSelector
 }
 

--- a/test/selectorsLibrary.js
+++ b/test/selectorsLibrary.js
@@ -488,6 +488,24 @@ test('setAttributeSelector | should set attribute all attribute selectors', (t) 
   t.is(rcs.selectorsLibrary.getIdSelector().attributeSelectors['=hello'].originalString, '[id="hello"]');
 });
 
+test('setAttributeSelector | attribute selector should fix previous mapping (see #96)', (t) => {
+  t.context.setSelectors();
+
+  let dotTestSelector = rcs.selectorsLibrary.get('.jp-selector');
+  t.is(dotTestSelector, 'b');
+
+  rcs.selectorsLibrary.getClassSelector().setAttributeSelector([
+    '[class^=jp-]',
+  ]);
+
+  dotTestSelector = rcs.selectorsLibrary.get('.jp-selector');
+  t.is(dotTestSelector, 'jp-t');
+
+  rcs.selectorsLibrary.set('.jp-trick');
+  dotTestSelector = rcs.selectorsLibrary.get('.jp-trick');
+  t.is(dotTestSelector, 'jp-n');
+});
+
 /* ************************ *
  * REPLACEATTRIBUTESELECTOR *
  * ************************ */


### PR DESCRIPTION
Fix #96 

I've chosen to implement the first solution, even if it's not optimal.
Whenever an attribute selector is found, all the existing selectors are tested against it and if they match, the remapping is modified to also match the renamed attribute selector. 