### PR TITLE
Fix: do not remove special characters when there is no match

### DIFF
--- a/__tests__/replace.css.ts
+++ b/__tests__/replace.css.ts
@@ -106,6 +106,7 @@ test('find selectors within targets | gulp-rcs#6', () => {
     '.a .b a[href="#a"]:before{}',
   );
 });
+
 it('should modify the code properly | filter oneline', () => {
   replaceCssMacro(
     '.somediv{filter: progid:DXImageTransform.Microsoft.gradient(enabled = false)}.anotherdiv{display:flex}',
@@ -615,5 +616,14 @@ it('replace css variables with deep nested and multiline | rename-css-selectors#
                 var(--c, var(--a, var(--not-renamed, 5px)))
       }
     `,
+  );
+});
+
+it('should replace excluded special characters | rename-css-selectors#77', () => {
+  rcs.selectorsLibrary.setExclude('somediv:test-me');
+
+  replaceCssMacro(
+    '.somediv\\:test-me{}.anotherdiv{}',
+    '.somediv\\:test-me{}.a{}',
   );
 });

--- a/lib/replace/css.ts
+++ b/lib/replace/css.ts
@@ -121,6 +121,12 @@ const replaceCss = (css: string | Buffer, opts: ReplaceCssOptions = {}): string 
       node.selectors = node.selectors.map((selector: string) => {
         const prefixFreeSelector = selector.replace(/\\/g, '');
 
+        // prevent returning prefixFreeSelectors
+        // when there is not even a match
+        if (!prefixFreeSelector.match(regex)) {
+          return selector;
+        }
+
         return prefixFreeSelector.replace(regex, (match) => (
           selectorLib.get(match, {
             addSelectorType: true,


### PR DESCRIPTION
Fixes https://github.com/JPeer264/node-rename-css-selectors/issues/77